### PR TITLE
adds statsd metrics for the rpc server

### DIFF
--- a/oslo_messaging/metrics.py
+++ b/oslo_messaging/metrics.py
@@ -1,0 +1,22 @@
+import logging
+import threading, queue
+import statsd
+
+LOG = logging.getLogger(__name__)
+
+class Metrics():
+   def __init__(self, host, port):
+      self._port = port
+      self.queue = queue.Queue()
+      self.statsd = statsd.StatsClient(host, port)
+
+   def start(self):
+      threading.Thread(target=self.counter, daemon=True).start()
+
+   def counter(self):
+      while True:
+         event = self.queue.get()
+         method = event.message.get('method')
+
+         stat = "oslo.messaging.{}.{}".format(method, event.message.tag)
+         self.statsd.incr(stat)

--- a/oslo_messaging/metrics.py
+++ b/oslo_messaging/metrics.py
@@ -3,37 +3,39 @@ import threading
 try:
     import queue
 except ImportError:
+    # python2 compatibility
     import Queue as queue
 
 import statsd
 
 LOG = logging.getLogger(__name__)
 
+
 class Metrics(object):
-   def __init__(self, host, port):
-      self.stop_event = threading.Event()
-      self.queue = queue.Queue()
-      self.statsd = statsd.StatsClient(host, port)
+    def __init__(self, host, port):
+        self.stop_event = threading.Event()
+        self.queue = queue.Queue()
+        self.statsd = statsd.StatsClient(host, port)
 
-   def start(self):
-      threading.Thread(target=self.counter, daemon=True).start()
+    def start(self):
+        threading.Thread(target=self.counter, daemon=True).start()
 
-   def stop(self):
-      self.stop_event.set()
+    def stop(self):
+        self.stop_event.set()
 
-   def counter(self):
-      while not self.stop_event.is_set():
-         try:
-            incoming = self.queue.get(timeout=1.0, block=True)
-         except queue.Empty:
-            continue
+    def counter(self):
+        while not self.stop_event.is_set():
+            try:
+                incoming = self.queue.get(timeout=1.0, block=True)
+            except queue.Empty:
+                continue
 
-         try:
-            message = incoming['message'].message
-            method = message.get('method')
-            stat = "oslo.messaging.{}.{}".format(method, incoming['tag'])
-            self.statsd.incr(stat)
-         except Exception:
-            LOG.exception('Exception during message metrics handling')
-         finally:
-            self.queue.task_done()
+            try:
+                message = incoming['message'].message
+                method = message.get('method')
+                stat = "oslo.messaging.{}.{}".format(method, incoming['tag'])
+                self.statsd.incr(stat)
+            except Exception:
+                LOG.exception('Exception during message metrics handling')
+            finally:
+                self.queue.task_done()

--- a/oslo_messaging/metrics.py
+++ b/oslo_messaging/metrics.py
@@ -1,0 +1,38 @@
+import logging
+import threading
+try:
+    import queue
+except ImportError:
+    import Queue as queue
+
+import statsd
+
+LOG = logging.getLogger(__name__)
+
+class Metrics(object):
+   def __init__(self, host, port):
+      self.stop_event = threading.Event()
+      self.queue = queue.Queue()
+      self.statsd = statsd.StatsClient(host, port)
+
+   def start(self):
+      threading.Thread(target=self.counter, daemon=True).start()
+
+   def stop(self):
+      self.stop_event.set()
+
+   def counter(self):
+      while not self.stop_event.is_set():
+         try:
+            incoming = self.queue.get(timeout=1.0, block=True)
+         except queue.Empty:
+            continue
+         try:
+            message = incoming['message'].message
+            method = message.get('method')
+            stat = "oslo.messaging.{}.{}".format(method, incoming['tag'])
+            self.statsd.incr(stat)
+         except Exception:
+            LOG.exception('Exception during message metrics handling')
+         finally:
+            self.queue.task_done()

--- a/oslo_messaging/rpc/server.py
+++ b/oslo_messaging/rpc/server.py
@@ -128,6 +128,10 @@ __all__ = [
 ]
 
 import logging
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 import sys
 
 from oslo_messaging._i18n import _LE
@@ -161,18 +165,25 @@ class RPCServer(msg_server.MessageHandlingServer):
             LOG.exception(_LE("Can not acknowledge message. Skip processing"))
             return
 
+
+        self.put_metrics_queue(message, 'event')
+
         failure = None
         try:
             res = self.dispatcher.dispatch(message)
         except rpc_dispatcher.ExpectedException as e:
             failure = e.exc_info
             LOG.debug(u'Expected exception during message handling (%s)', e)
+
+            self.put_metrics_queue(message, 'expected_exception')
         except Exception:
             # current sys.exc_info() content can be overridden
             # by another exception raised by a log handler during
             # LOG.exception(). So keep a copy and delete it later.
             failure = sys.exc_info()
-            LOG.exception(_LE('Exception during message handling'))
+            LOG.exception('Exception during message handling')
+
+            self.put_metrics_queue(message, 'exception')
 
         try:
             if failure is None:
@@ -186,6 +197,16 @@ class RPCServer(msg_server.MessageHandlingServer):
                 # between the current stack frame and the traceback in
                 # exc_info.
                 del failure
+
+    def put_metrics_queue(self, message, tag):
+        if self.conf.statsd_enabled:
+            try:
+                self.metrics.queue.put_nowait({
+                    'message': message,
+                    'tag': tag,
+                })
+            except queue.Full:
+                LOG.warning("Statsd metrics queue is full")
 
 
 def get_rpc_server(transport, target, endpoints,

--- a/oslo_messaging/rpc/server.py
+++ b/oslo_messaging/rpc/server.py
@@ -131,6 +131,7 @@ import logging
 try:
     import queue
 except ImportError:
+    # python2 compatibility
     import Queue as queue
 import sys
 

--- a/oslo_messaging/rpc/server.py
+++ b/oslo_messaging/rpc/server.py
@@ -179,7 +179,7 @@ class RPCServer(msg_server.MessageHandlingServer):
             # by another exception raised by a log handler during
             # LOG.exception(). So keep a copy and delete it later.
             failure = sys.exc_info()
-            LOG.exception('Exception during message handling')
+            LOG.exception(_LE('Exception during message handling'))
 
             self.put_metrics_queue(message, 'exception')
 

--- a/oslo_messaging/rpc/server.py
+++ b/oslo_messaging/rpc/server.py
@@ -160,20 +160,34 @@ class RPCServer(msg_server.MessageHandlingServer):
         except Exception:
             LOG.exception(_LE("Can not acknowledge message. Skip processing"))
             return
-
+        
+        if self.conf.statsd_enabled:
+            self.metrics.queue.put({
+                'message': message,
+                'tag': "event",
+            })
         failure = None
         try:
             res = self.dispatcher.dispatch(message)
         except rpc_dispatcher.ExpectedException as e:
             failure = e.exc_info
             LOG.debug(u'Expected exception during message handling (%s)', e)
+            if self.conf.statsd_enabled:
+                self.metrics.queue.put({
+                    'message': message,
+                    'tag': "expected_exception",
+                })
         except Exception:
             # current sys.exc_info() content can be overridden
             # by another exception raised by a log handler during
             # LOG.exception(). So keep a copy and delete it later.
             failure = sys.exc_info()
-            LOG.exception(_LE('Exception during message handling'))
-
+            LOG.exception('Exception during message handling')
+            if self.conf.statsd_enabled:
+                self.metrics.queue.put({
+                    'message': message,
+                    'tag': "exception",
+                })
         try:
             if failure is None:
                 message.reply(res)

--- a/oslo_messaging/server.py
+++ b/oslo_messaging/server.py
@@ -41,6 +41,7 @@ from stevedore import driver
 from oslo_messaging._drivers import base as driver_base
 from oslo_messaging._i18n import _LW
 from oslo_messaging import exceptions
+from oslo_messaging import metrics
 
 LOG = logging.getLogger(__name__)
 
@@ -55,6 +56,18 @@ _pool_opts = [
                deprecated_name="rpc_thread_pool_size",
                help='Size of executor thread pool when'
                ' executor is threading or eventlet.'),
+]
+
+_metrics_opts = [
+    cfg.IntOpt('statsd_port',
+               default=8125,
+               help='Port of the statsd service.'),
+    cfg.StrOpt('statsd_host',
+               default='localhost',
+               help='Host of the statsd service.'),
+    cfg.BoolOpt('statsd_enabled',
+               default=False,
+               help='Enables/Disables the metrics statsd server.'),
 ]
 
 
@@ -329,6 +342,10 @@ class MessageHandlingServer(service.ServiceBase, _OrderedTaskRunner):
         """
         self.conf = transport.conf
         self.conf.register_opts(_pool_opts)
+        self.conf.register_opts(_metrics_opts)
+
+        if self.conf.statsd_enabled:
+            self.metrics = metrics.Metrics(self.conf.statsd_host, self.conf.statsd_port)
 
         self.transport = transport
         self.dispatcher = dispatcher
@@ -417,6 +434,9 @@ class MessageHandlingServer(service.ServiceBase, _OrderedTaskRunner):
 
         self.listener.start(self._on_incoming)
 
+        if self.conf.statsd_enabled:
+            self.metrics.start()
+
     @ordered(after='start')
     def stop(self):
         """Stop handling incoming messages.
@@ -444,6 +464,10 @@ class MessageHandlingServer(service.ServiceBase, _OrderedTaskRunner):
 
         # Close listener connection after processing all messages
         self.listener.cleanup()
+       
+        # Stop metrics queue after all existing messages have been processed.
+        if self.conf.statsd_enabled:
+            self.metrics.stop()
 
     def reset(self):
         """Reset service.

--- a/oslo_messaging/server.py
+++ b/oslo_messaging/server.py
@@ -41,6 +41,7 @@ from stevedore import driver
 from oslo_messaging._drivers import base as driver_base
 from oslo_messaging._i18n import _LW
 from oslo_messaging import exceptions
+from oslo_messaging import metrics
 
 LOG = logging.getLogger(__name__)
 
@@ -55,6 +56,18 @@ _pool_opts = [
                deprecated_name="rpc_thread_pool_size",
                help='Size of executor thread pool when'
                ' executor is threading or eventlet.'),
+]
+
+_metrics_opts = [
+    cfg.IntOpt('statsd_port',
+               default=8125,
+               help='Port of the statsd service.'),
+    cfg.StrOpt('statsd_host',
+               default='localhost',
+               help='Host of the statsd service.'),
+    cfg.BoolOpt('statsd_enabled',
+               default=False,
+               help='Enables/Disables the metrics statsd server.'),
 ]
 
 
@@ -329,6 +342,11 @@ class MessageHandlingServer(service.ServiceBase, _OrderedTaskRunner):
         """
         self.conf = transport.conf
         self.conf.register_opts(_pool_opts)
+        self.conf.register_opts(_metrics_opts)
+
+        if self.conf.statsd_enabled:
+            self.metrics = metrics.Metrics(self.conf.statsd_host, self.conf.statsd_port)
+            self.metrics.start()
 
         self.transport = transport
         self.dispatcher = dispatcher


### PR DESCRIPTION
this change adds statsd metrics for the rpc server.
It uses a StatsClient and counts message events within a daemon thread.
the generated metrics contain the following data:
- method: name_of_the_called_rpc_method
- type: event|expected_exception|exception 

The statsdClient is disabled by default.