### PR TITLE
Send basic.cancel to broker in stop_consuming()

### DIFF
--- a/oslo_messaging/_drivers/impl_rabbit.py
+++ b/oslo_messaging/_drivers/impl_rabbit.py
@@ -1297,6 +1297,22 @@ class Connection(object):
 
     def stop_consuming(self):
         self._consume_loop_stopped = True
+        # Send basic.cancel to the broker for each consumer so RabbitMQ
+        # stops delivering messages immediately. Without this, the broker
+        # considers the consumer alive until the channel is closed (which
+        # happens much later in cleanup()). During graceful shutdown this
+        # creates a "zombie consumer" window where the broker round-robins
+        # messages to a consumer that is no longer processing them, causing
+        # message loss during rolling upgrades.
+        with self._connection_lock:
+            for consumer, tag in self._consumers.items():
+                try:
+                    consumer.cancel(tag=tag)
+                except Exception:
+                    # Best-effort cancellation. If the channel is already
+                    # broken we'll clean up in close() anyway.
+                    LOG.debug("Failed to cancel consumer %s on "
+                              "stop_consuming", tag)
 
     def declare_direct_consumer(self, topic, callback):
         """Create a 'direct' queue.

--- a/oslo_messaging/tests/drivers/test_impl_rabbit.py
+++ b/oslo_messaging/tests/drivers/test_impl_rabbit.py
@@ -447,6 +447,75 @@ class TestRabbitConsume(test_utils.BaseTestCase):
                 self.assertNotEqual(channel, conn.connection.channel)
 
 
+class TestRabbitStopConsuming(test_utils.BaseTestCase):
+
+    def test_stop_consuming_cancels_consumers(self):
+        """Verify stop_consuming sends basic.cancel for each consumer.
+
+        Without basic.cancel, the broker continues delivering messages to
+        a stopped consumer during graceful shutdown, causing message loss
+        in rolling upgrade scenarios.
+        """
+        transport = oslo_messaging.get_transport(self.conf, 'kombu+memory://')
+        self.addCleanup(transport.cleanup)
+        with transport._driver._get_connection(
+                driver_common.PURPOSE_LISTEN) as conn:
+            conn.declare_topic_consumer(exchange_name='test',
+                                        topic='test',
+                                        callback=lambda msg: True)
+            # There should be one consumer registered
+            self.assertEqual(1, len(conn.connection._consumers))
+
+            with mock.patch.object(
+                rabbit_driver.Consumer, 'cancel'
+            ) as mock_cancel:
+                conn.connection.stop_consuming()
+
+                # Verify the flag is set
+                self.assertTrue(conn.connection._consume_loop_stopped)
+                # Verify cancel was called for each consumer
+                self.assertEqual(1, mock_cancel.call_count)
+
+    def test_stop_consuming_cancels_multiple_consumers(self):
+        """Verify all consumers are cancelled when there are multiple."""
+        transport = oslo_messaging.get_transport(self.conf, 'kombu+memory://')
+        self.addCleanup(transport.cleanup)
+        with transport._driver._get_connection(
+                driver_common.PURPOSE_LISTEN) as conn:
+            conn.declare_topic_consumer(exchange_name='test',
+                                        topic='test1',
+                                        callback=lambda msg: True)
+            conn.declare_topic_consumer(exchange_name='test',
+                                        topic='test2',
+                                        callback=lambda msg: True)
+            conn.declare_fanout_consumer('test3', lambda msg: True)
+            self.assertEqual(3, len(conn.connection._consumers))
+
+            with mock.patch.object(
+                rabbit_driver.Consumer, 'cancel'
+            ) as mock_cancel:
+                conn.connection.stop_consuming()
+                self.assertEqual(3, mock_cancel.call_count)
+
+    def test_stop_consuming_tolerates_cancel_failure(self):
+        """Verify stop_consuming succeeds even if cancel raises."""
+        transport = oslo_messaging.get_transport(self.conf, 'kombu+memory://')
+        self.addCleanup(transport.cleanup)
+        with transport._driver._get_connection(
+                driver_common.PURPOSE_LISTEN) as conn:
+            conn.declare_topic_consumer(exchange_name='test',
+                                        topic='test',
+                                        callback=lambda msg: True)
+
+            with mock.patch.object(
+                rabbit_driver.Consumer, 'cancel',
+                side_effect=Exception('channel closed')
+            ):
+                # Should not raise
+                conn.connection.stop_consuming()
+                self.assertTrue(conn.connection._consume_loop_stopped)
+
+
 class TestRabbitTransportURL(test_utils.BaseTestCase):
 
     scenarios = [


### PR DESCRIPTION
## Summary

- Sends `Basic.Cancel` to RabbitMQ for each registered consumer in `stop_consuming()`, preventing message loss during graceful shutdown and rolling upgrades
- Without this fix, the broker continues delivering messages to a "zombie consumer" between `stop()` and `cleanup()`, causing permanent message loss for cast operations (e.g., Cinder `create_volume`)
- Best-effort cancellation: tolerates channel failures gracefully

## Upstream Review

https://review.opendev.org/c/openstack/oslo.messaging/+/986243

## Context

During Cinder graceful shutdown testing, an RPC cast was lost during a rolling update simulation. The message was sent to the backend-specific topic queue while both old and new services overlapped. Neither service processed it, leaving the volume stuck in 'creating' status indefinitely.

## Changes

- `oslo_messaging/_drivers/impl_rabbit.py`: Added `basic.cancel` loop in `stop_consuming()` 
- `oslo_messaging/tests/drivers/test_impl_rabbit.py`: Added `TestRabbitStopConsuming` test class with 3 tests covering single consumer, multiple consumers, and exception tolerance